### PR TITLE
Extract Ergebnisrechnung tables from balance PDFs

### DIFF
--- a/analysis/ergebnisrechnung/ergebnisrechnung_2019.csv
+++ b/analysis/ergebnisrechnung/ergebnisrechnung_2019.csv
@@ -1,0 +1,23 @@
+Spalte 13 (Kontenbereich),Spalte 24 (Lfd. Nr.),Spalte 3 (Ertrags- und Aufwandsarten),Spalte 4 (Ergebnis des Vorjahres in EUR),Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR),Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR),Spalte 7 (Vergleich Ansatz/Ist in EUR),Spalte 8 (Übertragene Ermächtigungen in EUR)
+40,1,Steuern und ähnliche Abgaben,"5.544.096,15","5.589.000,00","5.734.034,71","145.034,71-",-
+41,2,+ Zuwendungen und allgemeine Umlagen,"1.328.491,74","2.089.300,00","2.081.113,17","8.186,83",-
+42,3,+ Sonstige Transfererträge,"0,00","0,00","0,00","0,00",-
+43,4,+ öffentlich-rechtliche Leistungsentgelte,"206.274,55","172.400,00","188.723,06","16.323,06-",-
+"441, 442, 446",5,+ privatrechtliche Leistungsentgelte,"76.927,73","73.200,00","80.840,01","7.640,01-",-
+448,6,+ Kostenerstattungen u. Kostenumlagen,"2.483.319,08","2.567.800,00","2.606.329,93","38.529,93-",-
+45,7,+ sonstige Erträge,"733.500,02","553.000,00","582.555,79","29.555,79-",-
+471,8,+ aktivierte Eigenleistungen,"0,00","0,00","0,00","0,00",-
+472,9,+ / - Bestandveränderungen,"0,00","0,00","0,00","0,00",-
+,10,= Erträge,"10.372.609,27","11.044.700,00","11.273.596,67","228.896,67-",-
+50,11,Personalaufwendungen,"3.185.757,30","3.347.477,11","3.396.008,01","48.530,90-","169,31"
+51,12,+ Versorgungsaufwendungen,"28.747,14","31.601,86","27.991,82","3.610,04","0,00"
+52,13,+ Aufwendungen für Sach- und Dienstleistungen,"686.317,84","1.140.398,96","734.181,03","406.217,93","285.837,10"
+57,14,+ bilanzielle Abschreibungen,"490.665,27","455.500,00","488.016,19","32.516,19-","0,00"
+53,15,+ Transferaufwendungen,"4.922.764,62","4.851.704,69","4.853.268,78","1.564,09-","22.020,69"
+54,16,+ sonstige Aufwendungen,"543.973,91","959.481,62","1.251.757,91","292.276,29-","12.941,28"
+,17,= Aufwendungen,"9.858.226,08","10.786.164,24","10.751.223,74","34.940,50","320.968,38"
+,18,= Ergebnis der laufenden Verwaltungstätigkeit (=Zeilen 10 / 17),"514.383,19","258.535,76","522.372,93","263.837,17-","320.968,38-"
+46,19,+ Finanzerträge,"63.196,07","102.400,00","73.284,27","29.115,73",-
+55,20,- Zinsen und sonstige Finanzaufwendungen,"21.140,68-","25.200,00-","24.314,68-","885,32-","0,00"
+,21,= Finanzergebnis (= Zeilen 19 und 20),"42.055,39","77.200,00","48.969,59","28.230,41","0,00"
+,22,= Jahresergebnis 5 (= Zeilen 18 und 21),"556.438,58","335.735,76","571.342,52","235.606,76-","320.968,38-"

--- a/analysis/ergebnisrechnung/ergebnisrechnung_2020.csv
+++ b/analysis/ergebnisrechnung/ergebnisrechnung_2020.csv
@@ -1,0 +1,23 @@
+Spalte 13 (Kontenbereich),Spalte 24 (Lfd. Nr.),Spalte 3 (Ertrags- und Aufwandsarten),Spalte 4 (Ergebnis des Vorjahres in EUR),Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR),Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR),Spalte 7 (Vergleich Ansatz/Ist in EUR),Spalte 8 (Übertragene Ermächtigungen in EUR)
+40,1,Steuern und ähnliche Abgaben,"5.734.034,71","4.847.500,00","4.809.378,13","38.121,87",-
+41,2,+ Zuwendungen und allgemeine Umlagen,"2.081.113,17","2.067.900,00","2.882.152,36","814.252,36-",-
+42,3,+ Sonstige Transfererträge,"0,00","0,00","0,00","0,00",-
+43,4,+ öffentlich-rechtliche Leistungsentgelte,"188.723,06","144.700,00","143.165,05","1.534,95",-
+"441, 442, 446",5,+ privatrechtliche Leistungsentgelte,"80.840,01","69.600,00","425.088,86","355.488,86-",-
+448,6,+ Kostenerstattungen u. Kostenumlagen,"2.606.329,93","2.687.000,00","2.789.263,38","102.263,38-",-
+45,7,+ sonstige Erträge,"582.555,79","145.400,00","1.147.479,52","1.002.079,52-",-
+471,8,+ aktivierte Eigenleistungen,"0,00","0,00","0,00","0,00",-
+472,9,+ / - Bestandveränderungen,"0,00","0,00","0,00","0,00",-
+,10,= Erträge,"11.273.596,67","9.962.100,00","12.196.527,30","2.234.427,30-",-
+50,11,Personalaufwendungen,"3.396.008,01","3.642.669,31","3.436.501,46","206.167,85","0,00"
+51,12,+ Versorgungsaufwendungen,"27.991,82","31.100,00","11.570,88","19.529,12","0,00"
+52,13,+ Aufwendungen für Sach- und Dienstleistungen,"734.181,03","1.365.337,10","919.148,13","446.188,97","57.034,61"
+57,14,+ bilanzielle Abschreibungen,"488.016,19","447.500,00","464.989,18","17.489,18-","0,00"
+53,15,+ Transferaufwendungen,"4.853.268,78","4.648.020,69","4.551.528,85","96.491,84","1.000,00"
+54,16,+ sonstige Aufwendungen,"1.251.757,91","591.641,28","441.064,31","150.576,97","0,00"
+,17,= Aufwendungen,"10.751.223,74","10.726.268,38","9.824.802,81","901.465,57","58.034,61"
+,18,= Ergebnis der laufenden Verwaltungstätigkeit (=Zeilen 10 / 17),"522.372,93","764.168,38-","2.371.724,49","3.135.892,87-","58.034,61-"
+46,19,+ Finanzerträge,"73.284,27","101.400,00","69.664,67","31.735,33",-
+55,20,- Zinsen und sonstige Finanzaufwendungen,"24.314,68-","22.100,00-","43.361,29-","21.261,29","0,00"
+,21,= Finanzergebnis (= Zeilen 19 und 20),"48.969,59","79.300,00","26.303,38","52.996,62","0,00"
+,22,= Jahresergebnis 5 (= Zeilen 18 und 21),"571.342,52","684.868,38-","2.398.027,87","3.082.896,25-","58.034,61-"

--- a/analysis/ergebnisrechnung/ergebnisrechnung_2021.csv
+++ b/analysis/ergebnisrechnung/ergebnisrechnung_2021.csv
@@ -1,0 +1,23 @@
+Spalte 13 (Kontenbereich),Spalte 24 (Lfd. Nr.),Spalte 3 (Ertrags- und Aufwandsarten),Spalte 4 (Ergebnis des Vorjahres in EUR),Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR),Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR),Spalte 7 (Vergleich Ansatz/Ist in EUR),Spalte 8 (Übertragene Ermächtigungen in EUR)
+40,1,Steuern und ähnliche Abgaben,"4.809.378,13","4.903.700,00","6.122.902,62","1.219.202,62-",-
+41,2,+ Zuwendungen und allgemeine Umlagen,"2.882.152,36","2.076.200,00","2.389.188,40","312.988,40-",-
+42,3,+ Sonstige Transfererträge,"0,00","0,00","0,00","0,00",-
+43,4,+ öffentlich-rechtliche Leistungsentgelte,"143.165,05","144.600,00","159.642,29","15.042,29-",-
+"441, 442, 446",5,+ privatrechtliche Leistungsentgelte,"425.088,86","73.000,00","145.293,95","72.293,95-",-
+448,6,+ Kostenerstattungen u. Kostenumlagen,"2.789.263,38","3.223.500,00","2.684.446,17","539.053,83",-
+45,7,+ sonstige Erträge,"1.147.479,52","225.900,00","344.915,94","119.015,94-",-
+471,8,+ aktivierte Eigenleistungen,"0,00","0,00","0,00","0,00",-
+472,9,+ / - Bestandveränderungen,"0,00","0,00","0,00","0,00",-
+,10,= Erträge,"12.196.527,30","10.646.900,00","11.846.389,37","1.199.489,37-",-
+50,11,Personalaufwendungen,"3.436.501,46","3.947.000,00","3.434.291,14","512.708,86","0,00"
+51,12,+ Versorgungsaufwendungen,"11.570,88","29.900,00","11.094,74","18.805,26","0,00"
+52,13,+ Aufwendungen für Sach- und Dienstleistungen,"919.148,13","1.199.934,61","968.638,56","231.296,05","37.630,38"
+57,14,+ bilanzielle Abschreibungen,"464.989,18","454.900,00","442.132,54","12.767,46","0,00"
+53,15,+ Transferaufwendungen,"4.551.528,85","4.311.300,00","4.317.491,22","6.191,22-","0,00"
+54,16,+ sonstige Aufwendungen,"441.064,31","1.102.300,00","1.114.808,77","12.508,77-","0,00"
+,17,= Aufwendungen,"9.824.802,81","11.045.334,61","10.288.456,97","756.877,64","37.630,38"
+,18,= Ergebnis der laufenden Verwaltungstätigkeit (=Zeilen 10 / 17),"2.371.724,49","398.434,61-","1.557.932,40","1.956.367,01-","37.630,38-"
+46,19,+ Finanzerträge,"69.664,67","100.400,00","67.197,36","33.202,64",-
+55,20,- Zinsen und sonstige Finanzaufwendungen,"43.361,29-","19.500,00-","7.768,66-","11.731,34-","0,00"
+,21,= Finanzergebnis (= Zeilen 19 und 20),"26.303,38","80.900,00","59.428,70","21.471,30","0,00"
+,22,= Jahresergebnis 5 (= Zeilen 18 und 21),"2.398.027,87","317.534,61-","1.617.361,10","1.934.895,71-","37.630,38-"

--- a/analysis/ergebnisrechnung/ergebnisrechnung_2022.csv
+++ b/analysis/ergebnisrechnung/ergebnisrechnung_2022.csv
@@ -1,0 +1,23 @@
+Spalte 13 (Kontenbereich),Spalte 24 (Lfd. Nr.),Spalte 3 (Ertrags- und Aufwandsarten),Spalte 4 (Ergebnis des Vorjahres in EUR),Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR),Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR),Spalte 7 (Vergleich Ansatz/Ist in EUR),Spalte 8 (Übertragene Ermächtigungen in EUR)
+40,1,Steuern und ähnliche Abgaben,"6.122.902,62","5.526.900,00","9.019.607,70","3.492.707,70-",-
+41,2,+ Zuwendungen und allgemeine Umlagen,"2.389.188,40","2.505.100,00","2.764.693,92","259.593,92-",-
+42,3,+ Sonstige Transfererträge,"0,00","0,00","0,00","0,00",-
+43,4,+ öffentlich-rechtliche Leistungsentgelte,"159.642,29","144.800,00","216.262,12","71.462,12-",-
+"441, 442, 446",5,+ privatrechtliche Leistungsentgelte,"145.293,95","67.200,00","153.315,75","86.115,75-",-
+448,6,+ Kostenerstattungen u. Kostenumlagen,"2.684.446,17","2.862.000,00","2.822.168,81","39.831,19",-
+45,7,+ sonstige Erträge,"344.915,94","201.700,00","178.485,18","23.214,82",-
+471,8,+ aktivierte Eigenleistungen,"0,00","0,00","0,00","0,00",-
+472,9,+ / - Bestandveränderungen,"0,00","0,00","0,00","0,00",-
+,10,= Erträge,"11.846.389,37","11.307.700,00","15.154.533,48","3.846.833,48-",-
+50,11,Personalaufwendungen,"3.434.291,14","3.636.833,30","3.510.783,72","126.049,58","0,00"
+51,12,+ Versorgungsaufwendungen,"11.094,74","30.900,00","11.333,16","19.566,84","0,00"
+52,13,+ Aufwendungen für Sach- und Dienstleistungen,"968.638,56","1.450.697,08","1.039.463,38","411.233,70","282.034,42"
+57,14,+ bilanzielle Abschreibungen,"442.132,54","476.400,00","467.064,68","9.335,32","0,00"
+53,15,+ Transferaufwendungen,"4.317.491,22","4.983.400,00","5.253.054,58","269.654,58-","746,65"
+54,16,+ sonstige Aufwendungen,"1.114.808,77","1.277.600,00","1.208.625,78","68.974,22","20.004,00"
+,17,= Aufwendungen,"10.288.456,97","11.855.830,38","11.490.325,30","365.505,08","302.785,07"
+,18,= Ergebnis der laufenden Verwaltungstätigkeit (=Zeilen 10 / 17),"1.557.932,40","548.130,38-","3.664.208,18","4.212.338,56-","302.785,07-"
+46,19,+ Finanzerträge,"67.197,36","57.600,00","66.542,16","8.942,16-",-
+55,20,- Zinsen und sonstige Finanzaufwendungen,"7.768,66-","16.600,00-","4.952,69-","11.647,31-","0,00"
+,21,= Finanzergebnis (= Zeilen 19 und 20),"59.428,70","41.000,00","61.589,47","20.589,47-","0,00"
+,22,= Jahresergebnis 5 (= Zeilen 18 und 21),"1.617.361,10","507.130,38-","3.725.797,65","4.232.928,03-","302.785,07-"

--- a/analysis/ergebnisrechnung/ergebnisrechnung_2023.csv
+++ b/analysis/ergebnisrechnung/ergebnisrechnung_2023.csv
@@ -1,0 +1,23 @@
+Spalte 13 (Kontenbereich),Spalte 24 (Lfd. Nr.),Spalte 3 (Ertrags- und Aufwandsarten),Spalte 4 (Ergebnis des Vorjahres in EUR),Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR),Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR),Spalte 7 (Vergleich Ansatz/Ist in EUR),Spalte 8 (Übertragene Ermächtigungen in EUR)
+40,1,Steuern und ähnliche Abgaben,"9.019.607,70","7.871.200,00","8.634.446,44","763.246,44-",-
+41,2,+ Zuwendungen und allgemeine Umlagen,"2.764.693,92","2.643.800,00","2.577.797,67","66.002,33",-
+42,3,+ Sonstige Transfererträge,"0,00","0,00","0,00","0,00",-
+43,4,+ öffentlich-rechtliche Leistungsentgelte,"216.262,12","156.500,00","225.385,34","68.885,34-",-
+"441, 442, 446",5,+ privatrechtliche Leistungsentgelte,"153.315,75","88.000,00","161.761,29","73.761,29-",-
+448,6,+ Kostenerstattungen u. Kostenumlagen,"2.822.168,81","3.198.900,00","2.859.986,60","338.913,40",-
+45,7,+ sonstige Erträge,"178.485,18","308.600,00","674.563,40","365.963,40-",-
+471,8,+ aktivierte Eigenleistungen,"0,00","0,00","0,00","0,00",-
+472,9,+ / - Bestandveränderungen,"0,00","0,00","0,00","0,00",-
+,10,= Erträge,"15.154.533,48","14.267.000,00","15.133.940,74","866.940,74-",-
+50,11,Personalaufwendungen,"3.510.783,72","4.101.900,00","4.453.972,22","352.072,22-","0,00"
+51,12,+ Versorgungsaufwendungen,"11.333,16","30.600,00","11.882,49","18.717,51","0,00"
+52,13,+ Aufwendungen für Sach- und Dienstleistungen,"1.039.463,38","1.989.734,42","1.375.723,89","614.010,53","376.705,34"
+57,14,+ bilanzielle Abschreibungen,"467.064,68","444.000,00","537.635,47","93.635,47-","0,00"
+53,15,+ Transferaufwendungen,"5.253.054,58","5.979.246,65","5.736.277,06","242.969,59","258.432,65"
+54,16,+ sonstige Aufwendungen,"1.208.625,78","1.359.904,00","1.320.513,31","39.390,69","0,00"
+,17,= Aufwendungen,"11.490.325,30","13.905.385,07","13.436.004,44","469.380,63","635.137,99"
+,18,= Ergebnis der laufenden Verwaltungstätigkeit (=Zeilen 10 / 17),"3.664.208,18","361.614,93","1.697.936,30","1.336.321,37-","635.137,99-"
+46,19,+ Finanzerträge,"66.542,16","57.600,00","53.839,93","3.760,07",-
+55,20,- Zinsen und sonstige Finanzaufwendungen,"4.952,69-","16.600,00-","7.609,69-","8.990,31-","0,00"
+,21,= Finanzergebnis (= Zeilen 19 und 20),"61.589,47","41.000,00","46.230,24","5.230,24-","0,00"
+,22,= Jahresergebnis 5 (= Zeilen 18 und 21),"3.725.797,65","402.614,93","1.744.166,54","1.341.551,61-","635.137,99-"

--- a/analysis/ergebnisrechnung/ergebnisrechnung_2024.csv
+++ b/analysis/ergebnisrechnung/ergebnisrechnung_2024.csv
@@ -1,0 +1,25 @@
+Spalte 13 (Kontenbereich),Spalte 24 (Lfd. Nr.),Spalte 3 (Ertrags- und Aufwandsarten),Spalte 4 (Ergebnis des Vorjahres in EUR),Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR),Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR),Spalte 7 (Vergleich Ansatz/Ist in EUR),Spalte 8 (Übertragene Ermächtigungen in EUR)
+40,1,Steuern und ähnliche Abgaben,"8.634.446,44","6.795.300,00","7.424.229,54","628.929,54-",-
+41,2,+ Zuwendungen und allgemeine Umlagen,"2.577.797,67","1.721.200,00","1.550.911,59","170.288,41",-
+42,3,+ Sonstige Transfererträge,"0,00","0,00","0,00","0,00",-
+43,4,+ öffentlich-rechtliche Leistungsentgelte,"225.385,34","170.400,00","275.027,59","104.627,59-",-
+"441, 442, 446",5,+ privatrechtliche Leistungsentgelte,"161.761,29","111.500,00","179.396,41","67.896,41-",-
+448,6,+ Kostenerstattungen u. Kostenumlagen,"2.859.986,60","3.090.600,00","3.168.302,70","77.702,70-",-
+45,7,+ sonstige Erträge,"674.563,40","246.200,00","825.875,85","579.675,85-",-
+471,8,+ aktivierte Eigenleistungen,"0,00","0,00","0,00","0,00",-
+472,9,+ / - Bestandveränderungen,"0,00","0,00","0,00","0,00",-
+,10,= Erträge,"15.133.940,74","12.135.200,00","13.423.743,68","1.288.543,68-",-
+50,11,Personalaufwendungen,"4.453.972,22","4.430.000,00","5.290.282,58","860.282,58-","0,00"
+51,12,+ Versorgungsaufwendungen,"11.882,49","13.800,00","14.695,19","895,19-","0,00"
+52,13,+ Aufwendungen für Sach- und Dienstleistungen,"1.375.723,89","2.192.505,34","1.308.959,30","883.546,04","85.825,15"
+57,14,+ bilanzielle Abschreibungen,"537.635,47","487.700,00","635.682,03","147.982,03-","0,00"
+53,15,+ Transferaufwendungen,"5.736.277,06","6.876.932,65","6.590.297,55","286.635,10","169.203,00"
+54,16,+ sonstige Aufwendungen,"1.320.513,31","1.566.200,00","1.482.688,64","83.511,36","40.000,00"
+,17,= Aufwendungen,"13.436.004,44","15.567.137,99","15.322.605,29","244.532,70","295.028,15"
+,18,= Ergebnis der laufenden Verwaltungstätigkeit (=Zeilen 10 / 17),"1.697.936,30","3.431.937,99-","1.898.861,61-","1.533.076,38-","295.028,15-"
+46,19,+ Finanzerträge,"53.839,93","54.800,00","62.771,47","7.971,47-",-
+55,20,- Zinsen und sonstige Finanzaufwendungen,"7.609,69-","12.000,00-","20.382,44-","8.382,44","0,00"
+,21,= Finanzergebnis (= Zeilen 19 und 20),"46.230,24","42.800,00","42.389,03","410,97","0,00"
+,22,= Jahresergebnis (= Zeilen 18 und 21),"1.744.166,54","3.389.137,99-","1.856.472,58-","1.532.665,41-","295.028,15-"
+49,23,Inanspruchnahme der Ausgleichsrücklage nach § 26 Absatz 1 Satz 2 zum Haushalt-sausgleich,"0,00","2.754.000,00","0,00","2.754.000,00","0,00"
+,24,= Jahresergebnis unter Inanspruchnahme der Ausgleichsrücklage (= Zeilen 22 und 23),"1.744.166,54","635.137,99-","1.856.472,58-","1.221.334,59","295.028,15-"

--- a/analysis/extract_ergebnisrechnung.py
+++ b/analysis/extract_ergebnisrechnung.py
@@ -1,0 +1,94 @@
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+import pdfplumber
+
+TABLE_SETTINGS = {
+    "vertical_strategy": "lines",
+    "horizontal_strategy": "lines",
+}
+
+COLUMN_NAMES = [
+    "Spalte 13 (Kontenbereich)",
+    "Spalte 24 (Lfd. Nr.)",
+    "Spalte 3 (Ertrags- und Aufwandsarten)",
+    "Spalte 4 (Ergebnis des Vorjahres in EUR)",
+    "Spalte 5 (Fortgeschriebener Ansatz des Haushaltsjahres in EUR)",
+    "Spalte 6 (Ist-Ergebnis des Haushaltsjahres in EUR)",
+    "Spalte 7 (Vergleich Ansatz/Ist in EUR)",
+    "Spalte 8 (Übertragene Ermächtigungen in EUR)",
+]
+
+
+def clean_cell(cell: str | None) -> str:
+    if cell is None:
+        return ""
+    if not isinstance(cell, str):
+        return str(cell)
+    return " ".join(cell.split())
+
+
+def normalise_row(row: List[str | None], width: int) -> List[str]:
+    cleaned = [clean_cell(cell) for cell in row]
+    if len(cleaned) < width:
+        cleaned.extend([""] * (width - len(cleaned)))
+    return cleaned[:width]
+
+
+def extract_table_rows(table: List[List[str | None]]) -> Iterable[List[str]]:
+    if not table:
+        return []
+    width = len(table[0])
+    data_rows = []
+    for row in table[3:]:
+        normalised = normalise_row(row, width)
+        if all(cell == "" for cell in normalised):
+            continue
+        data_rows.append(normalised)
+    return data_rows
+
+
+def extract_ergebnis_rows(pdf_path: Path) -> List[List[str]]:
+    rows: List[List[str]] = []
+    with pdfplumber.open(pdf_path) as pdf:
+        in_section = False
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            if "Ergebnisrechnung" not in text or "Ertrags-" not in text:
+                if in_section:
+                    break
+                continue
+            in_section = True
+            tables = page.extract_tables(TABLE_SETTINGS)
+            for table in tables:
+                first_cell = table[0][0] if table and table[0] else ""
+                if "Ergebnisrechnung" not in (first_cell or ""):
+                    continue
+                rows.extend(extract_table_rows(table))
+    return rows
+
+
+def main() -> None:
+    input_dir = Path("input/balance")
+    output_dir = Path("analysis/ergebnisrechnung")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for pdf_path in sorted(input_dir.glob("Schlussbilanz *.pdf")):
+        match = re.search(r"(\d{4})", pdf_path.name)
+        if not match:
+            continue
+        year = match.group(1)
+        rows = extract_ergebnis_rows(pdf_path)
+        if not rows:
+            print(f"Keine Ergebnisrechnung in {pdf_path.name} gefunden.")
+            continue
+        df = pd.DataFrame(rows, columns=COLUMN_NAMES)
+        output_path = output_dir / f"ergebnisrechnung_{year}.csv"
+        df.to_csv(output_path, index=False)
+        print(f"{output_path} erstellt (Zeilen: {len(df)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests>=2.31.0
 beautifulsoup4>=4.12.2
+pandas>=2.3.0
+pdfplumber>=0.11.0


### PR DESCRIPTION
## Summary
- add a utility script that scans the Lensahn balance PDFs for the Ergebnisrechnung table and exports the rows to CSV
- commit the generated Ergebnisrechnung CSVs for the 2019–2024 balance documents
- add pandas and pdfplumber to the project dependencies for PDF table extraction

## Testing
- python analysis/extract_ergebnisrechnung.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b6e0a85883229a9b2e05b1744f9b