### PR TITLE
Add task logging guidance and document Lensahn consistency check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Instructions
+
+## Scope
+Diese Vorgaben gelten für das gesamte Repository.
+
+## Aufgabenprotokoll
+- Halte für jede erledigte Aufgabe ein Protokoll im Verzeichnis `log/tasks/` fest.
+- Der Dateiname muss mit dem aktuellen Datum im Format `YYYY-MM-DD_` beginnen und die Aufgabe sowie das Ergebnis dokumentieren.
+- Ergänze vorhandene Protokolle nicht rückwirkend, sondern lege für jede neue Aufgabe eine neue Datei an.
+- Stelle sicher, dass das Verzeichnis `log/tasks/` existiert.
+- Verweise bei Statusberichten auf relevante Quellen in diesem Repository.

--- a/log/tasks/2025-10-04_task_consistency.md
+++ b/log/tasks/2025-10-04_task_consistency.md
@@ -1,0 +1,20 @@
+# Task Log
+
+## Aufgabe
+- Überprüfung der Ergebnisrechnungen 2019–2024 der Gemeinde Lensahn auf Konsistenz zwischen den Jahren.
+- Dokumentation eventueller Inkonsistenzen und Erstellung eines dauerhaften Aufgaben-Logs.
+
+## Vorgehen
+- CSV-Dateien aus `analysis/ergebnisrechnung/` automatisiert eingelesen.
+- Spalte "Ergebnis des Vorjahres" mit dem Ist-Ergebnis des jeweiligen Vorjahres je Zeile verglichen.
+- Zusätzlich wurde auf Änderungen in der Tabellenstruktur (fehlende oder neue Positionen) geprüft.
+
+## Ergebnisse
+- Für die Jahre 2020–2024 stimmen die ausgewiesenen Vorjahresergebnisse mit den jeweiligen Ist-Ergebnissen des Vorjahres überein.
+- In der Ergebnisrechnung 2024 wurden strukturelle Anpassungen festgestellt:
+  - Die Position `= Jahresergebnis 5 (= Zeilen 18 und 21)` aus 2023 wurde in `= Jahresergebnis (= Zeilen 18 und 21)` umbenannt, bleibt aber inhaltlich verknüpft (Vorjahreswert 1.744.166,54 EUR entspricht dem Ist-Ergebnis 2023).
+  - Neue Zeilen wurden ergänzt: `Inanspruchnahme der Ausgleichsrücklage ...` sowie `= Jahresergebnis unter Inanspruchnahme der Ausgleichsrücklage ...`. Diese hatten 2023 noch keine Entsprechung.
+- Keine numerischen Inkonsistenzen zwischen den Jahren identifiziert.
+
+## Nächste Schritte
+- Bei zukünftigen Ergänzungen weiterer Jahrgänge denselben Abgleich ausführen und etwaige neue Strukturänderungen dokumentieren.


### PR DESCRIPTION
## Summary
- add an AGENTS.md with repository-wide guidance to log every future task under `log/tasks/`
- record the current Lensahn 2019-2024 consistency review, including structural changes found in 2024

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0bd1f65c48322b835214b1564de87