### PR TITLE
Add report on gesamt ergebnisse time series trends

### DIFF
--- a/analysis/ergebnisrechnung/2025-10-04_bericht_gesamt_ergebnisse.md
+++ b/analysis/ergebnisrechnung/2025-10-04_bericht_gesamt_ergebnisse.md
@@ -1,0 +1,32 @@
+# Bericht zu Auffälligkeiten in der Ergebnisrechnung (Gesamt-Ergebnisse 2018–2024)
+
+## Datenbasis
+- Quelle: `analysis/ergebnisrechnung/gesamt_ergebnisse_zeitreihe.csv`
+- Betrachtete Kennzahlen: Gesamterträge, Gesamtaufwendungen, Ergebnis der laufenden Verwaltungstätigkeit, Finanzergebnis, Jahresergebnis sowie zentrale Ertrags- und Aufwandsarten.
+
+## Zentrale Entwicklungen
+1. **Rekordjahr 2022 mit anschließender Gegenbewegung**
+   - Die Gesamterträge erreichten 2022 mit 15,15 Mio. € ihren Höchststand (+27,9 % ggü. 2021), fielen 2024 jedoch auf 13,42 Mio. € zurück (−1,73 Mio. € ggü. 2022).
+   - Der Rückgang ist vor allem auf die Ertragsarten „Steuern und ähnliche Abgaben“ (2022: 9,02 Mio. €; 2024: 7,42 Mio. €) und „Zuwendungen und allgemeine Umlagen“ (2022: 2,76 Mio. €; 2024: 1,55 Mio. €) zurückzuführen.
+
+2. **Überproportional steigende Aufwendungen**
+   - Die Gesamtaufwendungen stiegen nach einem moderaten Plus 2022 (+11,7 %) besonders stark 2023 (+16,9 %) und nochmals 2024 (+14,0 %) auf 15,32 Mio. € an.
+   - Größte Treiber zwischen 2022 und 2024: Personalaufwendungen (+1,78 Mio. €), Transferaufwendungen (+1,34 Mio. €) sowie sonstige Aufwendungen (+0,36 Mio. €). Sach- und Dienstleistungen blieben dagegen nahezu konstant (2024: 1,31 Mio. €; 2022: 1,25 Mio. €).
+
+3. **Ergebnisdrehung 2024**
+   - Das Ergebnis der laufenden Verwaltungstätigkeit kippte von +3,66 Mio. € (2022) über +1,70 Mio. € (2023) auf −1,90 Mio. € (2024).
+   - Entsprechend rutschte das ausgewiesene Jahresergebnis 2024 unter Inanspruchnahme der Ausgleichsrücklage auf −1,86 Mio. €, nachdem 2023 noch +1,74 Mio. € erzielt wurden.
+
+4. **Stabiles, aber geringes Finanzergebnis**
+   - Das Finanzergebnis blieb über den gesamten Zeitraum mit 0,04–0,06 Mio. € sehr klein; der Rückgang 2024 (0,04 Mio. €) verstärkt die Negativentwicklung der laufenden Verwaltung nur marginal.
+
+## Auffälligkeiten im Detail
+- Die Ertragsstruktur ist stark von Steuern abhängig: Selbst nach dem Rückgang 2024 machen sie über 55 % der Gesamterträge aus.
+- 2023 brachte einen einmaligen Anstieg der sonstigen Erträge (0,68 Mio. €) nach dem Tief 2022 (0,09 Mio. €); 2024 setzte sich der Aufholtrend mit 0,83 Mio. € fort.
+- Trotz leichter Entspannung bei Sach- und Dienstleistungen (2024: −0,05 Mio. € ggü. 2023) kompensieren die deutlichen Mehrkosten beim Personal und den Transferaufwendungen diese Effekte deutlich.
+- Zwischen 2022 und 2024 verschlechterte sich der Saldo aus laufender Verwaltung um rund 5,56 Mio. €; der Großteil entfällt auf die Kombination aus sinkenden Steuereinnahmen (−1,60 Mio. €) und steigenden Personal- sowie Transferaufwendungen (+3,12 Mio. € zusammen).
+
+## Hinweise für die weitere Analyse
+- Prüfen, ob die Steuererträge 2022 durch Sondereffekte (z. B. Nachzahlungen) verzerrt sind.
+- Ursachen für den starken Anstieg der Personal- und Transferaufwendungen 2023/2024 identifizieren (z. B. Tarifabschlüsse, neue Leistungsprogramme).
+- Szenarioanalyse zur Konsolidierung: Welche Einsparvolumina oder Mehreinnahmen wären erforderlich, um wieder ein positives Ergebnis der laufenden Verwaltung zu erreichen?

--- a/log/tasks/2025-10-04_bericht_gesamt_ergebnisse.md
+++ b/log/tasks/2025-10-04_bericht_gesamt_ergebnisse.md
@@ -1,0 +1,9 @@
+# Aufgabe
+Bericht zu Auffälligkeiten und Tendenzen in `analysis/ergebnisrechnung/gesamt_ergebnisse_zeitreihe.csv` erstellen und im gleichen Verzeichnis ablegen.
+
+# Umsetzung
+- Datensatz eingelesen und zentrale Kennzahlen (Erträge, Aufwendungen, Jahresergebnis) analysiert.
+- Trends und Auffälligkeiten schriftlich im Bericht `analysis/ergebnisrechnung/2025-10-04_bericht_gesamt_ergebnisse.md` dokumentiert.
+
+# Ergebnis
+- Bericht mit Kernaussagen zu Spitzenjahr 2022, steigenden Aufwendungen, Ergebnisdrehung 2024 und stabil geringem Finanzergebnis erstellt. 【F:analysis/ergebnisrechnung/2025-10-04_bericht_gesamt_ergebnisse.md†L7-L33】


### PR DESCRIPTION
## Summary
- add a dated report in analysis/ergebnisrechnung that highlights key trends and anomalies in gesamt_ergebnisse_zeitreihe.csv
- log the completion of the reporting task in log/tasks with pointers to the new document

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0cdb44c5c8322a4cfe1bda9a9a368