### PR TITLE
Add teilergebnis exports for positive revenue categories

### DIFF
--- a/analysis/ergebnisrechnung/teilergebnis_2019_finanzerträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_finanzerträge.csv
@@ -1,0 +1,6 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,46,19,Finanzerträge,Gesamtsumme,,,73284.27
+2019,46,19,Finanzerträge,Teilergebnis,111004,Finanzbuchhaltung,7.18
+2019,46,19,Finanzerträge,Teilergebnis,522000,Wohnungsbauförderung,1921.51
+2019,46,19,Finanzerträge,Teilergebnis,532000,Gasversorgung,64684.02
+2019,46,19,Finanzerträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,6671.56

--- a/analysis/ergebnisrechnung/teilergebnis_2019_kostenerstattungen_u_kostenumlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_kostenerstattungen_u_kostenumlagen.csv
@@ -1,0 +1,32 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Gesamtsumme,,,2606329.93
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111000,Gemeindeorgane,218440.80
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111001,Hauptamt,226032.04
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111002,Gleichstellungsbeauftragte,1664.00
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111003,Finanzverwaltung,155616.16
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111004,Finanzbuchhaltung,65067.26
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111005,Liegenschaftsverwaltung,30658.98
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111006,Elektronische Datenverarbeitung,42604.16
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111007,Eigene Bauverwaltung,26374.04
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,123986.43
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122001,Asylbewerber,132040.29
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122200,Melde- und Personenstandswesen,101233.94
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,126000,Gemeindewehrführer,14935.81
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,374678.53
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,243000,Sonstige schulische Aufgaben,39737.17
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,63780.34
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,312000,Grundsicherung nach SGB II,75168.81
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,351000,Leistungen nach dem Wohngeldgesetz,39361.06
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,361100,Förderung Kindertageseinrichtungen,442751.21
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424001,Großsporthalle,34574.43
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424002,Sportplatz,41031.03
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,511000,Bauleitplanung,17442.26
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,521000,Bauordnung,10962.06
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,533000,Wasserversorgung,188900.67
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541000,Gemeindestraßen,39829.80
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541001,Straßenbeleuchtung,16475.86
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,547000,Öffentlicher Personennahverkehr,16798.04
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551000,Grünanlagen,12640.18
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551001,Kinderspielplätze,6133.30
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573900,Bauhof,14383.25
+2019,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,575000,Fremdenverkehr,33028.02

--- a/analysis/ergebnisrechnung/teilergebnis_2019_privatrechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_privatrechtliche_leistungsentgelte.csv
@@ -1,0 +1,24 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Gesamtsumme,,,80840.01
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111001,Hauptamt,100.00
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111005,Liegenschaftsverwaltung,36571.63
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,22.00
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,478.12
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126001,FF Lensahn,1682.91
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126002,FF Lensahnerhof,4978.05
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126003,FF Sipsdorf,842.55
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126004,FF Wahrendorf,116.98
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,1636.51
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,281000,Heimat- und sonstige Kulturpflege,277.88
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,331000,Förderung der Wohlfahrtspflege,5128.45
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,8786.82
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424003,Sport- und Vereinsheim,413.57
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424004,Schießsportanlage,366.49
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424005,Kegelbahn,4240.26
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,537000,Abfallbeseitigung,2753.23
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,538001,öffentliche Toiletten,321.30
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,2714.57
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,153.38
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,551000,Grünanlagen,3551.16
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,5700.15
+2019,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573900,Bauhof,4.00

--- a/analysis/ergebnisrechnung/teilergebnis_2019_sonstige_erträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_sonstige_erträge.csv
@@ -1,0 +1,13 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,45,7,sonstige Erträge,Gesamtsumme,,,582555.79
+2019,45,7,sonstige Erträge,Teilergebnis,111000,Gemeindeorgane,1562.33
+2019,45,7,sonstige Erträge,Teilergebnis,111003,Finanzverwaltung,30950.75
+2019,45,7,sonstige Erträge,Teilergebnis,111004,Finanzbuchhaltung,7239.83
+2019,45,7,sonstige Erträge,Teilergebnis,111005,Liegenschaftsverwaltung,313901.60
+2019,45,7,sonstige Erträge,Teilergebnis,111006,Elektronische Datenverarbeitung,21111.54
+2019,45,7,sonstige Erträge,Teilergebnis,531000,Elektritzitätsversorgung,132678.39
+2019,45,7,sonstige Erträge,Teilergebnis,532000,Gasversorgung,27038.12
+2019,45,7,sonstige Erträge,Teilergebnis,533000,Wasserversorgung,36600.28
+2019,45,7,sonstige Erträge,Teilergebnis,573900,Bauhof,2916.37
+2019,45,7,sonstige Erträge,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",8547.60
+2019,45,7,sonstige Erträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,8.98

--- a/analysis/ergebnisrechnung/teilergebnis_2019_steuern_und_ähnliche_abgaben.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_steuern_und_ähnliche_abgaben.csv
@@ -1,0 +1,3 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,40,1,Steuern und ähnliche Abgaben,Gesamtsumme,,,5734034.71
+2019,40,1,Steuern und ähnliche Abgaben,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",5734034.71

--- a/analysis/ergebnisrechnung/teilergebnis_2019_zuwendungen_und_allgemeine_umlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_zuwendungen_und_allgemeine_umlagen.csv
@@ -1,0 +1,19 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,41,2,Zuwendungen und allgemeine Umlagen,Gesamtsumme,,,2081113.17
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,111001,Hauptamt,9121.68
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126001,FF Lensahn,6872.93
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126002,FF Lensahnerhof,1282.26
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126003,FF Sipsdorf,561.12
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126004,FF Wahrendorf,2482.20
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,10067.16
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,272000,Gemeindebücherei,14755.00
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424000,Waldschwimmbad,18991.76
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424003,Sport- und Vereinsheim,977.82
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424004,Schießsportanlage,2139.84
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541000,Gemeindestraßen,197450.02
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541001,Straßenbeleuchtung,868.44
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551001,Kinderspielplätze,2645.34
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,553900,Ehrenfriedhof,564.00
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573000,Veranstaltungssaal,1153.98
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573002,Eingangsbereich,115.62
+2019,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",1811064.00

--- a/analysis/ergebnisrechnung/teilergebnis_2019_öffentlich-rechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2019_öffentlich-rechtliche_leistungsentgelte.csv
@@ -1,0 +1,10 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Gesamtsumme,,,188723.06
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,4407.00
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,11333.03
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,2524.90
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,75635.51
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,39811.00
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,499.86
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,28242.46
+2019,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,26269.30

--- a/analysis/ergebnisrechnung/teilergebnis_2020_finanzerträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_finanzerträge.csv
@@ -1,0 +1,6 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,46,19,Finanzerträge,Gesamtsumme,,,69664.67
+2020,46,19,Finanzerträge,Teilergebnis,111004,Finanzbuchhaltung,7.18
+2020,46,19,Finanzerträge,Teilergebnis,522000,Wohnungsbauförderung,1915.77
+2020,46,19,Finanzerträge,Teilergebnis,532000,Gasversorgung,62949.04
+2020,46,19,Finanzerträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,4792.68

--- a/analysis/ergebnisrechnung/teilergebnis_2020_kostenerstattungen_u_kostenumlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_kostenerstattungen_u_kostenumlagen.csv
@@ -1,0 +1,34 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Gesamtsumme,,,2789263.38
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111000,Gemeindeorgane,237576.57
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111001,Hauptamt,201807.77
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111002,Gleichstellungsbeauftragte,1900.00
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111003,Finanzverwaltung,230940.58
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111004,Finanzbuchhaltung,77260.87
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111005,Liegenschaftsverwaltung,35132.89
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111006,Elektronische Datenverarbeitung,67199.19
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111007,Eigene Bauverwaltung,91906.90
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,133629.44
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122001,Asylbewerber,87270.31
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122200,Melde- und Personenstandswesen,128035.00
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,126000,Gemeindewehrführer,13902.31
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,400509.88
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,243000,Sonstige schulische Aufgaben,39875.63
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,272000,Gemeindebücherei,99.54
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,137583.32
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,312000,Grundsicherung nach SGB II,85891.90
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,351000,Leistungen nach dem Wohngeldgesetz,43162.43
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,361100,Förderung Kindertageseinrichtungen,449595.62
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424000,Waldschwimmbad,5893.61
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424001,Großsporthalle,36743.08
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,511000,Bauleitplanung,35932.83
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,521000,Bauordnung,12184.90
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,533000,Wasserversorgung,160388.70
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541000,Gemeindestraßen,-8745.24
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541001,Straßenbeleuchtung,-4568.28
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,547000,Öffentlicher Personennahverkehr,22793.93
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551000,Grünanlagen,-1747.91
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551001,Kinderspielplätze,21197.98
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573000,Veranstaltungssaal,377.00
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573900,Bauhof,11813.93
+2020,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,575000,Fremdenverkehr,33718.70

--- a/analysis/ergebnisrechnung/teilergebnis_2020_privatrechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_privatrechtliche_leistungsentgelte.csv
@@ -1,0 +1,23 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Gesamtsumme,,,425088.86
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111001,Hauptamt,250.00
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111005,Liegenschaftsverwaltung,35207.52
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126001,FF Lensahn,1957.97
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126002,FF Lensahnerhof,685.20
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126003,FF Sipsdorf,1042.99
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126004,FF Wahrendorf,12.18
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,1164.00
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,281000,Heimat- und sonstige Kulturpflege,323.80
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,331000,Förderung der Wohlfahrtspflege,8031.20
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,8021.15
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424003,Sport- und Vereinsheim,430.35
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424004,Schießsportanlage,2380.90
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424005,Kegelbahn,6884.24
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,533000,Wasserversorgung,332045.45
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,537000,Abfallbeseitigung,3545.69
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,17063.58
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,3913.34
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,551000,Grünanlagen,-2947.38
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,4752.08
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573900,Bauhof,265.97
+2020,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,58.63

--- a/analysis/ergebnisrechnung/teilergebnis_2020_sonstige_erträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_sonstige_erträge.csv
@@ -1,0 +1,15 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,45,7,sonstige Erträge,Gesamtsumme,,,1147479.52
+2020,45,7,sonstige Erträge,Teilergebnis,111000,Gemeindeorgane,82966.93
+2020,45,7,sonstige Erträge,Teilergebnis,111003,Finanzverwaltung,22104.88
+2020,45,7,sonstige Erträge,Teilergebnis,111004,Finanzbuchhaltung,921.19
+2020,45,7,sonstige Erträge,Teilergebnis,111005,Liegenschaftsverwaltung,362.12
+2020,45,7,sonstige Erträge,Teilergebnis,111006,Elektronische Datenverarbeitung,118.57
+2020,45,7,sonstige Erträge,Teilergebnis,111007,Eigene Bauverwaltung,16628.13
+2020,45,7,sonstige Erträge,Teilergebnis,531000,Elektritzitätsversorgung,134390.66
+2020,45,7,sonstige Erträge,Teilergebnis,532000,Gasversorgung,12809.12
+2020,45,7,sonstige Erträge,Teilergebnis,533000,Wasserversorgung,36796.71
+2020,45,7,sonstige Erträge,Teilergebnis,551001,Kinderspielplätze,8314.08
+2020,45,7,sonstige Erträge,Teilergebnis,573900,Bauhof,16628.13
+2020,45,7,sonstige Erträge,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",15439.00
+2020,45,7,sonstige Erträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,800000.00

--- a/analysis/ergebnisrechnung/teilergebnis_2020_steuern_und_ähnliche_abgaben.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_steuern_und_ähnliche_abgaben.csv
@@ -1,0 +1,3 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,40,1,Steuern und ähnliche Abgaben,Gesamtsumme,,,4809378.13
+2020,40,1,Steuern und ähnliche Abgaben,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",4809378.13

--- a/analysis/ergebnisrechnung/teilergebnis_2020_zuwendungen_und_allgemeine_umlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_zuwendungen_und_allgemeine_umlagen.csv
@@ -1,0 +1,22 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,41,2,Zuwendungen und allgemeine Umlagen,Gesamtsumme,,,2882152.36
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,111001,Hauptamt,9121.68
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126001,FF Lensahn,7766.33
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126002,FF Lensahnerhof,1282.27
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126003,FF Sipsdorf,540.30
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126004,FF Wahrendorf,2482.20
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,10525.63
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,272000,Gemeindebücherei,15511.39
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424000,Waldschwimmbad,19434.82
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424002,Sportplatz,840.99
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424003,Sport- und Vereinsheim,977.82
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424004,Schießsportanlage,2139.84
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541000,Gemeindestraßen,197310.84
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541001,Straßenbeleuchtung,868.49
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551000,Grünanlagen,70.00
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551001,Kinderspielplätze,2402.43
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,553900,Ehrenfriedhof,594.00
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573000,Veranstaltungssaal,1153.92
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573002,Eingangsbereich,115.62
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,575000,Fremdenverkehr,834.08
+2020,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",2608179.71

--- a/analysis/ergebnisrechnung/teilergebnis_2020_öffentlich-rechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2020_öffentlich-rechtliche_leistungsentgelte.csv
@@ -1,0 +1,10 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Gesamtsumme,,,143165.05
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,3163.00
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,4167.14
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,2270.90
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,58324.69
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,39972.00
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,499.86
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,9479.33
+2020,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,25288.13

--- a/analysis/ergebnisrechnung/teilergebnis_2021_finanzerträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_finanzerträge.csv
@@ -1,0 +1,6 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,46,19,Finanzerträge,Gesamtsumme,,,67197.36
+2021,46,19,Finanzerträge,Teilergebnis,111004,Finanzbuchhaltung,3.31
+2021,46,19,Finanzerträge,Teilergebnis,522000,Wohnungsbauförderung,1909.92
+2021,46,19,Finanzerträge,Teilergebnis,532000,Gasversorgung,62418.66
+2021,46,19,Finanzerträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,2865.47

--- a/analysis/ergebnisrechnung/teilergebnis_2021_kostenerstattungen_u_kostenumlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_kostenerstattungen_u_kostenumlagen.csv
@@ -1,0 +1,34 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Gesamtsumme,,,2684446.17
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111000,Gemeindeorgane,219338.95
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111001,Hauptamt,243762.39
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111002,Gleichstellungsbeauftragte,1884.00
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111003,Finanzverwaltung,248997.05
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111004,Finanzbuchhaltung,79555.79
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111005,Liegenschaftsverwaltung,35031.70
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111006,Elektronische Datenverarbeitung,68234.06
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111007,Eigene Bauverwaltung,62675.49
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,162372.64
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122001,Asylbewerber,65569.56
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122200,Melde- und Personenstandswesen,113726.57
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,126000,Gemeindewehrführer,31610.60
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,433408.91
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,243000,Sonstige schulische Aufgaben,35804.68
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,272000,Gemeindebücherei,13.00
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,71077.29
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,312000,Grundsicherung nach SGB II,98129.40
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,351000,Leistungen nach dem Wohngeldgesetz,38654.33
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,361100,Förderung Kindertageseinrichtungen,287426.89
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,362500,Sonstige Jugendarbeit,4003.91
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424001,Großsporthalle,36928.61
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424002,Sportplatz,26345.71
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,511000,Bauleitplanung,45305.70
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,521000,Bauordnung,10142.09
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,533000,Wasserversorgung,160826.09
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541000,Gemeindestraßen,9916.73
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541001,Straßenbeleuchtung,4919.38
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,547000,Öffentlicher Personennahverkehr,17293.35
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551000,Grünanlagen,4911.58
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551001,Kinderspielplätze,20052.40
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573900,Bauhof,12397.63
+2021,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,575000,Fremdenverkehr,34129.69

--- a/analysis/ergebnisrechnung/teilergebnis_2021_privatrechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_privatrechtliche_leistungsentgelte.csv
@@ -1,0 +1,29 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Gesamtsumme,,,145293.95
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111000,Gemeindeorgane,1922.21
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111001,Hauptamt,776.70
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111005,Liegenschaftsverwaltung,33932.45
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,3014.80
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,1178.24
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126001,FF Lensahn,2719.65
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126002,FF Lensahnerhof,120.00
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126003,FF Sipsdorf,1676.17
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,1178.29
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,1231.50
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,281000,Heimat- und sonstige Kulturpflege,2742.96
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,3844.98
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,331000,Förderung der Wohlfahrtspflege,5551.38
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,361100,Förderung Kindertageseinrichtungen,699.90
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,21103.39
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424002,Sportplatz,5879.25
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424003,Sport- und Vereinsheim,716.82
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424004,Schießsportanlage,733.72
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424005,Kegelbahn,6034.45
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,537000,Abfallbeseitigung,3003.69
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,9405.19
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,6838.85
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,551000,Grünanlagen,350.15
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,5051.09
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573002,Eingangsbereich,0.19
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573900,Bauhof,24546.59
+2021,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,1041.34

--- a/analysis/ergebnisrechnung/teilergebnis_2021_sonstige_erträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_sonstige_erträge.csv
@@ -1,0 +1,17 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,45,7,sonstige Erträge,Gesamtsumme,,,344915.94
+2021,45,7,sonstige Erträge,Teilergebnis,111000,Gemeindeorgane,43955.36
+2021,45,7,sonstige Erträge,Teilergebnis,111003,Finanzverwaltung,14840.52
+2021,45,7,sonstige Erträge,Teilergebnis,111004,Finanzbuchhaltung,1915.78
+2021,45,7,sonstige Erträge,Teilergebnis,111006,Elektronische Datenverarbeitung,4381.19
+2021,45,7,sonstige Erträge,Teilergebnis,111007,Eigene Bauverwaltung,3221.30
+2021,45,7,sonstige Erträge,Teilergebnis,126001,FF Lensahn,14999.00
+2021,45,7,sonstige Erträge,Teilergebnis,126100,JF Lensahn,399.00
+2021,45,7,sonstige Erträge,Teilergebnis,531000,Elektritzitätsversorgung,129594.14
+2021,45,7,sonstige Erträge,Teilergebnis,532000,Gasversorgung,16658.45
+2021,45,7,sonstige Erträge,Teilergebnis,533000,Wasserversorgung,38063.10
+2021,45,7,sonstige Erträge,Teilergebnis,551000,Grünanlagen,70128.78
+2021,45,7,sonstige Erträge,Teilergebnis,551001,Kinderspielplätze,1610.71
+2021,45,7,sonstige Erträge,Teilergebnis,573900,Bauhof,3221.30
+2021,45,7,sonstige Erträge,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",1911.00
+2021,45,7,sonstige Erträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,16.31

--- a/analysis/ergebnisrechnung/teilergebnis_2021_steuern_und_ähnliche_abgaben.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_steuern_und_ähnliche_abgaben.csv
@@ -1,0 +1,3 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,40,1,Steuern und ähnliche Abgaben,Gesamtsumme,,,6122902.62
+2021,40,1,Steuern und ähnliche Abgaben,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",6122902.62

--- a/analysis/ergebnisrechnung/teilergebnis_2021_zuwendungen_und_allgemeine_umlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_zuwendungen_und_allgemeine_umlagen.csv
@@ -1,0 +1,22 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,41,2,Zuwendungen und allgemeine Umlagen,Gesamtsumme,,,2389188.40
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,111001,Hauptamt,9121.68
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126001,FF Lensahn,8913.74
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126002,FF Lensahnerhof,1282.32
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126003,FF Sipsdorf,462.76
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126004,FF Wahrendorf,1922.62
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,10564.05
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,272000,Gemeindebücherei,15761.44
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424000,Waldschwimmbad,156484.19
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424002,Sportplatz,3363.96
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424003,Sport- und Vereinsheim,977.82
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424004,Schießsportanlage,2139.84
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541000,Gemeindestraßen,209855.04
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541001,Straßenbeleuchtung,868.50
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551000,Grünanlagen,420.00
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551001,Kinderspielplätze,1673.94
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,553900,Ehrenfriedhof,594.00
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573000,Veranstaltungssaal,380.76
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573002,Eingangsbereich,115.62
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,575000,Fremdenverkehr,1572.58
+2021,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",1962713.54

--- a/analysis/ergebnisrechnung/teilergebnis_2021_öffentlich-rechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2021_öffentlich-rechtliche_leistungsentgelte.csv
@@ -1,0 +1,10 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Gesamtsumme,,,159642.29
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,5151.00
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,1663.46
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,1895.30
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,68390.51
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,39738.00
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,499.86
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,16745.32
+2021,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,25558.84

--- a/analysis/ergebnisrechnung/teilergebnis_2022_finanzerträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_finanzerträge.csv
@@ -1,0 +1,6 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,46,19,Finanzerträge,Gesamtsumme,,,66542.16
+2022,46,19,Finanzerträge,Teilergebnis,111004,Finanzbuchhaltung,4.42
+2022,46,19,Finanzerträge,Teilergebnis,522000,Wohnungsbauförderung,1862.93
+2022,46,19,Finanzerträge,Teilergebnis,532000,Gasversorgung,63852.88
+2022,46,19,Finanzerträge,Teilergebnis,612000,sonstige allg. Finanzwirtschaft,821.93

--- a/analysis/ergebnisrechnung/teilergebnis_2022_kostenerstattungen_u_kostenumlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_kostenerstattungen_u_kostenumlagen.csv
@@ -1,0 +1,34 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Gesamtsumme,,,2822168.81
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111000,Gemeindeorgane,365947.42
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111001,Hauptamt,289435.15
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111003,Finanzverwaltung,277631.82
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111004,Finanzbuchhaltung,90675.02
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111005,Liegenschaftsverwaltung,36017.48
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111006,Elektronische Datenverarbeitung,142532.29
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111007,Eigene Bauverwaltung,66610.25
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,179796.28
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122001,Asylbewerber,54972.33
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122200,Melde- und Personenstandswesen,119774.48
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,126000,Gemeindewehrführer,13939.24
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,443823.68
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,243000,Sonstige schulische Aufgaben,37811.13
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,272000,Gemeindebücherei,5.00
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,132189.59
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,312000,Grundsicherung nach SGB II,98946.90
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,351000,Leistungen nach dem Wohngeldgesetz,35916.57
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,361100,Förderung Kindertageseinrichtungen,12543.59
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,362500,Sonstige Jugendarbeit,15380.99
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424000,Waldschwimmbad,617.48
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424001,Großsporthalle,37349.67
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424002,Sportplatz,28393.19
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,511000,Bauleitplanung,47020.07
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,521000,Bauordnung,9343.18
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,533000,Wasserversorgung,174974.98
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541000,Gemeindestraßen,9857.90
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541001,Straßenbeleuchtung,4446.44
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,547000,Öffentlicher Personennahverkehr,17497.96
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551000,Grünanlagen,2751.53
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551001,Kinderspielplätze,24035.63
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573900,Bauhof,13070.23
+2022,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,575000,Fremdenverkehr,38861.34

--- a/analysis/ergebnisrechnung/teilergebnis_2022_privatrechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_privatrechtliche_leistungsentgelte.csv
@@ -1,0 +1,26 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Gesamtsumme,,,153315.75
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111005,Liegenschaftsverwaltung,34549.95
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,4908.02
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,942.44
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126001,FF Lensahn,3135.76
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126002,FF Lensahnerhof,1415.34
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126003,FF Sipsdorf,3217.86
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126004,FF Wahrendorf,314.40
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126100,JF Lensahn,598.10
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,1655.55
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,281000,Heimat- und sonstige Kulturpflege,237.80
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,331000,Förderung der Wohlfahrtspflege,4454.20
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,13057.94
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424002,Sportplatz,3242.64
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424003,Sport- und Vereinsheim,462.11
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424004,Schießsportanlage,511.73
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424005,Kegelbahn,4927.38
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,511001,Städtebausanierung,42662.72
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,533000,Wasserversorgung,1.00
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,537000,Abfallbeseitigung,3566.40
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,6262.56
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,10088.03
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,9517.24
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573900,Bauhof,2122.58
+2022,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,1464.00

--- a/analysis/ergebnisrechnung/teilergebnis_2022_sonstige_erträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_sonstige_erträge.csv
@@ -1,0 +1,8 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,45,7,sonstige Erträge,Gesamtsumme,,,178485.18
+2022,45,7,sonstige Erträge,Teilergebnis,111000,Gemeindeorgane,3067.00
+2022,45,7,sonstige Erträge,Teilergebnis,111004,Finanzbuchhaltung,1151.44
+2022,45,7,sonstige Erträge,Teilergebnis,531000,Elektritzitätsversorgung,126080.00
+2022,45,7,sonstige Erträge,Teilergebnis,532000,Gasversorgung,8329.23
+2022,45,7,sonstige Erträge,Teilergebnis,533000,Wasserversorgung,39586.51
+2022,45,7,sonstige Erträge,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",271.00

--- a/analysis/ergebnisrechnung/teilergebnis_2022_steuern_und_ähnliche_abgaben.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_steuern_und_ähnliche_abgaben.csv
@@ -1,0 +1,3 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,40,1,Steuern und ähnliche Abgaben,Gesamtsumme,,,9019607.70
+2022,40,1,Steuern und ähnliche Abgaben,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",9019607.70

--- a/analysis/ergebnisrechnung/teilergebnis_2022_zuwendungen_und_allgemeine_umlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_zuwendungen_und_allgemeine_umlagen.csv
@@ -1,0 +1,24 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,41,2,Zuwendungen und allgemeine Umlagen,Gesamtsumme,,,2764693.92
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,111001,Hauptamt,9121.68
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126001,FF Lensahn,11370.20
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126002,FF Lensahnerhof,1623.24
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126003,FF Sipsdorf,571.34
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126004,FF Wahrendorf,1619.38
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,10769.33
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,272000,Gemeindebücherei,16430.65
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424000,Waldschwimmbad,163875.02
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424002,Sportplatz,4062.86
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424003,Sport- und Vereinsheim,977.82
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424004,Schießsportanlage,2139.84
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,511000,Bauleitplanung,16275.00
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,511001,Städtebausanierung,2666.66
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541000,Gemeindestraßen,210143.09
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541001,Straßenbeleuchtung,1312.86
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551000,Grünanlagen,420.00
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551001,Kinderspielplätze,1534.44
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,553900,Ehrenfriedhof,594.00
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573000,Veranstaltungssaal,309.69
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573002,Eingangsbereich,115.62
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,575000,Fremdenverkehr,1571.04
+2022,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",2307190.16

--- a/analysis/ergebnisrechnung/teilergebnis_2022_öffentlich-rechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2022_öffentlich-rechtliche_leistungsentgelte.csv
@@ -1,0 +1,10 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Gesamtsumme,,,216262.12
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,6592.00
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,2676.06
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,2649.60
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,104644.49
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,40321.00
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,499.86
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,33255.43
+2022,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,575000,Fremdenverkehr,25623.68

--- a/analysis/ergebnisrechnung/teilergebnis_2023_finanzerträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_finanzerträge.csv
@@ -1,0 +1,5 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,46,19,Finanzerträge,Gesamtsumme,,,53839.93
+2023,46,19,Finanzerträge,Teilergebnis,111004,Finanzbuchhaltung,13.42
+2023,46,19,Finanzerträge,Teilergebnis,522000,Wohnungsbauförderung,1858.39
+2023,46,19,Finanzerträge,Teilergebnis,532000,Gasversorgung,51968.12

--- a/analysis/ergebnisrechnung/teilergebnis_2023_kostenerstattungen_u_kostenumlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_kostenerstattungen_u_kostenumlagen.csv
@@ -1,0 +1,35 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Gesamtsumme,,,2859986.60
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111000,Gemeindeorgane,228377.56
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111001,Hauptamt,255433.30
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111002,Gleichstellungsbeauftragte,1884.00
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111003,Finanzverwaltung,283997.53
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111004,Finanzbuchhaltung,87008.31
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111005,Liegenschaftsverwaltung,36969.15
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111006,Elektronische Datenverarbeitung,160645.76
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111007,Eigene Bauverwaltung,91717.31
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,174380.54
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122001,Asylbewerber,101103.34
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122200,Melde- und Personenstandswesen,122393.05
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,126000,Gemeindewehrführer,53275.74
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,457100.26
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,243000,Sonstige schulische Aufgaben,52223.13
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,99092.91
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,312000,Grundsicherung nach SGB II,110381.36
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,351000,Leistungen nach dem Wohngeldgesetz,76500.46
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,361100,Förderung Kindertageseinrichtungen,14314.52
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,362500,Sonstige Jugendarbeit,91.31
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424000,Waldschwimmbad,26.31
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424001,Großsporthalle,36763.25
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424002,Sportplatz,41313.82
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,511000,Bauleitplanung,48829.37
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,521000,Bauordnung,11494.98
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,533000,Wasserversorgung,186426.32
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541000,Gemeindestraßen,24964.70
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541001,Straßenbeleuchtung,15305.28
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,547000,Öffentlicher Personennahverkehr,16926.20
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551000,Grünanlagen,10.47
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551001,Kinderspielplätze,13071.61
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573000,Veranstaltungssaal,5465.35
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573900,Bauhof,12417.57
+2023,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,575000,Tourismus,40081.83

--- a/analysis/ergebnisrechnung/teilergebnis_2023_privatrechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_privatrechtliche_leistungsentgelte.csv
@@ -1,0 +1,26 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Gesamtsumme,,,161761.29
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111000,Gemeindeorgane,120.70
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111001,Hauptamt,143.75
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111005,Liegenschaftsverwaltung,51455.97
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,5504.42
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,1340.35
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126001,FF Lensahn,1614.22
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126002,FF Lensahnerhof,1077.45
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126003,FF Sipsdorf,11410.75
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126004,FF Wahrendorf,466.84
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,2742.25
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,281000,Heimat- und sonstige Kulturpflege,367.00
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,331000,Förderung der Wohlfahrtspflege,8124.70
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,15987.96
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424002,Sportplatz,3320.05
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424003,Sport- und Vereinsheim,529.82
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424004,Schießsportanlage,1129.48
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424005,Kegelbahn,7343.61
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,537000,Abfallbeseitigung,3050.32
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,8269.22
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,31116.80
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,551000,Grünanlagen,350.00
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,5070.05
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573900,Bauhof,1131.04
+2023,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,575000,Tourismus,94.54

--- a/analysis/ergebnisrechnung/teilergebnis_2023_sonstige_erträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_sonstige_erträge.csv
@@ -1,0 +1,14 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,45,7,sonstige Erträge,Gesamtsumme,,,674563.40
+2023,45,7,sonstige Erträge,Teilergebnis,111000,Gemeindeorgane,54332.60
+2023,45,7,sonstige Erträge,Teilergebnis,111003,Finanzverwaltung,56876.00
+2023,45,7,sonstige Erträge,Teilergebnis,111004,Finanzbuchhaltung,5340.50
+2023,45,7,sonstige Erträge,Teilergebnis,111006,Elektronische Datenverarbeitung,11011.00
+2023,45,7,sonstige Erträge,Teilergebnis,111007,Eigene Bauverwaltung,10420.00
+2023,45,7,sonstige Erträge,Teilergebnis,126001,FF Lensahn,-90.00
+2023,45,7,sonstige Erträge,Teilergebnis,531000,Elektritzitätsversorgung,125891.29
+2023,45,7,sonstige Erträge,Teilergebnis,532000,Gasversorgung,20941.08
+2023,45,7,sonstige Erträge,Teilergebnis,533000,Wasserversorgung,39080.48
+2023,45,7,sonstige Erträge,Teilergebnis,551001,Kinderspielplätze,5209.00
+2023,45,7,sonstige Erträge,Teilergebnis,573900,Bauhof,10417.00
+2023,45,7,sonstige Erträge,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",335134.45

--- a/analysis/ergebnisrechnung/teilergebnis_2023_steuern_und_ähnliche_abgaben.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_steuern_und_ähnliche_abgaben.csv
@@ -1,0 +1,3 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,40,1,Steuern und ähnliche Abgaben,Gesamtsumme,,,8634446.44
+2023,40,1,Steuern und ähnliche Abgaben,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",8634446.44

--- a/analysis/ergebnisrechnung/teilergebnis_2023_zuwendungen_und_allgemeine_umlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_zuwendungen_und_allgemeine_umlagen.csv
@@ -1,0 +1,25 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,41,2,Zuwendungen und allgemeine Umlagen,Gesamtsumme,,,2577797.67
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,111001,Hauptamt,9121.68
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126001,FF Lensahn,11975.32
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126002,FF Lensahnerhof,1501.00
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126003,FF Sipsdorf,1874.68
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126004,FF Wahrendorf,93.06
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,10825.23
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,272000,Gemeindebücherei,12008.49
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424000,Waldschwimmbad,53580.17
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424002,Sportplatz,4062.90
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424003,Sport- und Vereinsheim,977.82
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424004,Schießsportanlage,2139.84
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424005,Kegelbahn,1834.95
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,511000,Bauleitplanung,11245.50
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,511001,Städtebausanierung,31999.92
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,538001,öffentliche Toiletten,1500.00
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541000,Gemeindestraßen,210300.97
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541001,Straßenbeleuchtung,1312.86
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551000,Grünanlagen,420.00
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,553900,Ehrenfriedhof,594.00
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573000,Veranstaltungssaal,238.62
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573002,Eingangsbereich,115.62
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,575000,Tourismus,1571.04
+2023,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",2208504.00

--- a/analysis/ergebnisrechnung/teilergebnis_2023_öffentlich-rechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2023_öffentlich-rechtliche_leistungsentgelte.csv
@@ -1,0 +1,11 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Gesamtsumme,,,225385.34
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,8732.00
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122200,Melde- und Personenstandswesen,100.00
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,1414.97
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,2574.40
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,98718.08
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,39910.00
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,499.86
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,47277.32
+2023,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,575000,Tourismus,26158.71

--- a/analysis/ergebnisrechnung/teilergebnis_2024_finanzerträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_finanzerträge.csv
@@ -1,0 +1,5 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,46,19,Finanzerträge,Gesamtsumme,,,62771.47
+2024,46,19,Finanzerträge,Teilergebnis,362502,Kinder- und Jugendstiftung,84.45
+2024,46,19,Finanzerträge,Teilergebnis,522000,Wohnungsbauförderung,1834.64
+2024,46,19,Finanzerträge,Teilergebnis,532000,Gasversorgung,60852.38

--- a/analysis/ergebnisrechnung/teilergebnis_2024_kostenerstattungen_u_kostenumlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_kostenerstattungen_u_kostenumlagen.csv
@@ -1,0 +1,32 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Gesamtsumme,,,3168302.70
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111000,Gemeindeorgane,262610.88
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111001,Hauptamt,302334.07
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111002,Gleichstellungsbeauftragte,1884.00
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111003,Finanzverwaltung,343769.61
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111004,Finanzbuchhaltung,89155.50
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111005,Liegenschaftsverwaltung,39926.15
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111006,Elektronische Datenverarbeitung,156542.61
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,111007,Eigene Bauverwaltung,74569.79
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,179899.48
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122001,Asylbewerber,125891.92
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,122200,Melde- und Personenstandswesen,142646.42
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,126000,Gemeindewehrführer,56331.03
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,579482.04
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,243000,Sonstige schulische Aufgaben,53667.50
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,272000,Gemeindebücherei,105.84
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,311000,Verwaltung der Grundsicherung nach SGB XII,126475.81
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,312000,Grundsicherung nach SGB II,99701.47
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,351000,Leistungen nach dem Wohngeldgesetz,80036.25
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,361100,Förderung Kindertageseinrichtungen,18663.76
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424001,Großsporthalle,40491.37
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,424002,Sportplatz,32873.41
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,511000,Bauleitplanung,48729.32
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,521000,Bauordnung,11059.22
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,533000,Wasserversorgung,198400.25
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541000,Gemeindestraßen,30464.52
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,541001,Straßenbeleuchtung,11810.28
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,547000,Öffentlicher Personennahverkehr,5194.67
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,551001,Kinderspielplätze,578.73
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,573900,Bauhof,12458.83
+2024,448,6,Kostenerstattungen u. Kostenumlagen,Teilergebnis,575000,Tourismus,42547.97

--- a/analysis/ergebnisrechnung/teilergebnis_2024_privatrechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_privatrechtliche_leistungsentgelte.csv
@@ -1,0 +1,26 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Gesamtsumme,,,179396.41
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111000,Gemeindeorgane,271.77
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111001,Hauptamt,370.91
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,111005,Liegenschaftsverwaltung,111130.77
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,-6942.27
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126001,FF Lensahn,2943.65
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126002,FF Lensahnerhof,1049.79
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126003,FF Sipsdorf,1485.04
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,126004,FF Wahrendorf,638.14
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,4360.99
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,281000,Heimat- und sonstige Kulturpflege,568.40
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,331000,Förderung der Wohlfahrtspflege,3884.73
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,14203.05
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424002,Sportplatz,5752.03
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424003,Sport- und Vereinsheim,575.21
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424004,Schießsportanlage,2380.69
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,424005,Kegelbahn,7995.33
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,511000,Bauleitplanung,6000.00
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,531000,Elektritzitätsversorgung,1915.86
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,537000,Abfallbeseitigung,2676.47
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,4120.19
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,6541.93
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,5367.56
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573002,Eingangsbereich,1097.32
+2024,"441, 442, 446",5,privatrechtliche Leistungsentgelte,Teilergebnis,573900,Bauhof,1008.85

--- a/analysis/ergebnisrechnung/teilergebnis_2024_sonstige_erträge.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_sonstige_erträge.csv
@@ -1,0 +1,16 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,45,7,sonstige Erträge,Gesamtsumme,,,825875.85
+2024,45,7,sonstige Erträge,Teilergebnis,111000,Gemeindeorgane,32795.00
+2024,45,7,sonstige Erträge,Teilergebnis,111003,Finanzverwaltung,86116.17
+2024,45,7,sonstige Erträge,Teilergebnis,111004,Finanzbuchhaltung,49047.80
+2024,45,7,sonstige Erträge,Teilergebnis,111006,Elektronische Datenverarbeitung,137198.21
+2024,45,7,sonstige Erträge,Teilergebnis,111007,Eigene Bauverwaltung,112983.84
+2024,45,7,sonstige Erträge,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,70.00
+2024,45,7,sonstige Erträge,Teilergebnis,424000,Waldschwimmbad,6378.11
+2024,45,7,sonstige Erträge,Teilergebnis,531000,Elektritzitätsversorgung,130880.00
+2024,45,7,sonstige Erträge,Teilergebnis,532000,Gasversorgung,13418.05
+2024,45,7,sonstige Erträge,Teilergebnis,533000,Wasserversorgung,47245.06
+2024,45,7,sonstige Erträge,Teilergebnis,541000,Gemeindestraßen,2489.00
+2024,45,7,sonstige Erträge,Teilergebnis,551001,Kinderspielplätze,56491.42
+2024,45,7,sonstige Erträge,Teilergebnis,573900,Bauhof,146962.19
+2024,45,7,sonstige Erträge,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",3801.00

--- a/analysis/ergebnisrechnung/teilergebnis_2024_steuern_und_ähnliche_abgaben.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_steuern_und_ähnliche_abgaben.csv
@@ -1,0 +1,3 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,40,1,Steuern und ähnliche Abgaben,Gesamtsumme,,,7424229.54
+2024,40,1,Steuern und ähnliche Abgaben,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",7424229.54

--- a/analysis/ergebnisrechnung/teilergebnis_2024_zuwendungen_und_allgemeine_umlagen.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_zuwendungen_und_allgemeine_umlagen.csv
@@ -1,0 +1,24 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,41,2,Zuwendungen und allgemeine Umlagen,Gesamtsumme,,,1550911.59
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,111001,Hauptamt,9121.68
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126001,FF Lensahn,15942.59
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126002,FF Lensahnerhof,1501.02
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126003,FF Sipsdorf,2047.52
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,126004,FF Wahrendorf,93.06
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,218200,Grund- und Gemeinschaftsschule Lensahn,13704.37
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,272000,Gemeindebücherei,15970.37
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424000,Waldschwimmbad,35641.85
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424002,Sportplatz,4597.72
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424003,Sport- und Vereinsheim,977.82
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424004,Schießsportanlage,2139.84
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,424005,Kegelbahn,4403.88
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,511001,Städtebausanierung,58467.00
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,538001,öffentliche Toiletten,3000.00
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541000,Gemeindestraßen,208187.79
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,541001,Straßenbeleuchtung,1312.86
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,551000,Grünanlagen,420.00
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,553900,Ehrenfriedhof,594.00
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573000,Veranstaltungssaal,238.62
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,573002,Eingangsbereich,115.62
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,575000,Tourismus,1570.98
+2024,41,2,Zuwendungen und allgemeine Umlagen,Teilergebnis,611000,"Steuern, allg. Zuweisungen, allg. Umlagen",1170863.00

--- a/analysis/ergebnisrechnung/teilergebnis_2024_öffentlich-rechtliche_leistungsentgelte.csv
+++ b/analysis/ergebnisrechnung/teilergebnis_2024_öffentlich-rechtliche_leistungsentgelte.csv
@@ -1,0 +1,10 @@
+jahr,kontenbereich,laufende_nummer,art,scope,produkt,produkt_name,ist_ergebnis_eur
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Gesamtsumme,,,275027.59
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,122000,Allgemeine Ordnungsangelegenheiten,41402.96
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,126000,Gemeindewehrführer,332.01
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,272000,Gemeindebücherei,2636.50
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,424000,Waldschwimmbad,114448.65
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541000,Gemeindestraßen,39805.00
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,541001,Straßenbeleuchtung,499.86
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,573000,Veranstaltungssaal,47637.87
+2024,43,4,öffentlich-rechtliche Leistungsentgelte,Teilergebnis,575000,Tourismus,28264.74

--- a/log/tasks/2025-10-04_extract_teilergebnisse_mehrjahre.md
+++ b/log/tasks/2025-10-04_extract_teilergebnisse_mehrjahre.md
@@ -1,0 +1,6 @@
+# Aufgabe: Teilergebnisse für positive Ertragsarten
+
+- Script `bin/extract_account_teilergebnisse.py` für alle Jahre 2019–2024 je Ertragsart mit positivem Ist-Ergebnis ausgeführt.
+- Insgesamt 7 Ertragsarten je Jahr verarbeitet: Steuern und ähnliche Abgaben, Zuwendungen und allgemeine Umlagen, öffentlich-rechtliche Leistungsentgelte, privatrechtliche Leistungsentgelte, Kostenerstattungen u. Kostenumlagen, sonstige Erträge sowie Finanzerträge.
+- Ausgaben als CSV unter `analysis/ergebnisrechnung/teilergebnis_<jahr>_<art>.csv` gespeichert (z. B. `analysis/ergebnisrechnung/teilergebnis_2024_steuern_und_ähnliche_abgaben.csv`).
+- Ergebnisdateien dienen als Grundlage für weitere Auswertungen der Ergebnisrechnung.


### PR DESCRIPTION
## Summary
- generate CSV teilergebnis exports for every positive Ertragsart in the Ergebnisrechnung for 2019–2024 using `extract_account_teilergebnisse.py`
- store the outputs in `analysis/ergebnisrechnung/` alongside the existing 2024 Kostenerstattungen file
- document the activity in `log/tasks/2025-10-04_extract_teilergebnisse_mehrjahre.md`

## Testing
- ```bash
python - <<'PY'
import csv, pathlib, re, importlib.util, sys
from decimal import Decimal
import pdfplumber

module_name = "extract_account_teilergebnisse"
spec = importlib.util.spec_from_file_location(module_name, "bin/extract_account_teilergebnisse.py")
extract = importlib.util.module_from_spec(spec)
sys.modules[module_name] = extract
spec.loader.exec_module(extract)

from pdfplumber.page import Page
orig_extract_tables = Page.extract_tables

def cached_extract_tables(self, table_settings=None, *args, **kwargs):
    cache = getattr(self, "_extract_tables_cache", {})
    key = tuple(sorted((table_settings or {}).items()))
    if key not in cache:
        cache[key] = orig_extract_tables(self, table_settings, *args, **kwargs)
        self._extract_tables_cache = cache
    return cache[key]

Page.extract_tables = cached_extract_tables

def parse(value):
    value = value.strip()
    if not value:
        return Decimal('0')
    neg = False
    if value.endswith('-'):
        neg = True
        value = value[:-1]
    value = value.replace('.', '').replace(',', '.')
    if not value:
        return Decimal('0')
    num = Decimal(value)
    if neg:
        num *= -1
    return num

def first_digit(text: str) -> str:
    match = re.search(r'\d', text)
    return match.group(0) if match else ''


def positive_accounts(year: str):
    path = pathlib.Path('analysis/ergebnisrechnung') / f'ergebnisrechnung_{year}.csv'
    accounts = []
    with path.open(encoding='utf-8') as f:
        reader = csv.reader(f)
        next(reader)
        for row in reader:
            if not row:
                continue
            art = row[2].strip()
            if not art or art.startswith('='):
                continue
            if first_digit(row[0]) != '4':
                continue
            val = parse(row[5])
            if val > 0:
                accounts.append(art.lstrip('+-= ').strip())
    return accounts


years = [p.stem.split('_')[-1] for p in sorted(pathlib.Path('analysis/ergebnisrechnung').glob('ergebnisrechnung_*.csv'))]
for year in years:
    accounts = positive_accounts(year)
    pdf_path = extract.build_default_pdf_path(year)
    print(f"Processing {year} using {pdf_path} for {len(accounts)} accounts")
    with pdfplumber.open(pdf_path) as pdf:
        for account in accounts:
            print(f"  extracting {account}")
            summary = extract.extract_ergebnis_summary(pdf, account)
            entries = extract.extract_teilergebnis_entries(pdf, account)
            extract.check_consistency(summary, entries)
            output_path = pathlib.Path('analysis/ergebnisrechnung') / (
                f"teilergebnis_{year}_{account.lower().replace(' ', '_').replace('.', '')}.csv"
            )
            extract.write_output_csv(output_path, year, summary, entries)
PY
```

------
https://chatgpt.com/codex/tasks/task_e_68e110156908832291163bbba99f914f